### PR TITLE
本番環境用のCICDワークフローを追加

### DIFF
--- a/.github/workflows/publish-draft.yml
+++ b/.github/workflows/publish-draft.yml
@@ -2,7 +2,6 @@ name: Publish for orbit portal of draft.
 on:
   push:
     branches:
-      - wip-*
       - draft
     paths-ignore:
       - "README.md"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,39 +1,50 @@
-name: PublishForGitHubPages
+name: Publish for orbit portal.
 on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "README.md"
+      - "doc/*"
 jobs:
-  build:
-    name: Build & Publish OrbitUserManual
+  publish:
+    name: Publish portal
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
+      - uses: actions/checkout@v2.1.0
+      - uses: actions/setup-node@v1.4.2
         with:
           node-version: 12.x
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.ORBIT_SS_PRD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.ORBIT_SS_PRD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - name: CreateEnvJson
+        uses: schdck/create-env-json@v1
+        id: create-env
+        with:
+          file-name: "src/.vuepress/env.json"
+          BASE_URL: "https://api.orbit.jvckenwood.com/organization/v1"
+          API_KEY: ""
       - name: Build
-        run: |
-          npm install
-          npm run build
-      - name: Publish
-        uses: maxheld83/ghpages@v0.2.1
-        env:
-          BUILD_DIR: release
-          GH_PAT: ${{ secrets.GH_PAT }}
+        run: npm install && npm run build
+      - name: Deploy
+        uses: ItsKarma/aws-cli@v1.70.0
+        with:
+          args: s3 sync --delete --acl bucket-owner-read --exact-timestamps release/ s3://orbit.jvckenwood.com/
       - name: Slack Notification Success
         if: success()
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_USERNAME: "Orbit UserManual"
-          SLACK_TITLE: "Publish Success"
-          SLACK_MESSAGE: "https://orbit.jvckenwood-dev.com"
-          SLACK_WEBHOOK: ${{ secrets.ORBIT_DOC_SLACK_WEBHOOK }}
+          SLACK_USERNAME: "[OrbitPortal] Deploy Success"
+          SLACK_WEBHOOK: ${{ secrets.ORBIT_CICD_SLACK_WEBHOOK }}
+          SLACK_ICON: 'https://avatars0.githubusercontent.com/u/44036562?s=100'
       - name: Slack Notification Failure
         if: failure()
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_USERNAME: "Orbit UserManual"
-          SLACK_TITLE: "Publish Failed"
-          SLACK_WEBHOOK: ${{ secrets.ORBIT_DOC_SLACK_WEBHOOK }}
+          SLACK_USERNAME: "[OrbitPortal] Deploy Failure"
+          SLACK_WEBHOOK: ${{ secrets.ORBIT_CICD_SLACK_WEBHOOK }}
+          SLACK_ICON: 'https://avatars0.githubusercontent.com/u/44036562?s=100'
           SLACK_COLOR: "#FF0000"


### PR DESCRIPTION
ポータルサイトの本番環境デプロイ用のGitHubActionを追加しました。
基本的には、draftブランチと同様で、トリガとなるブランチや設定が異なるだけです。
APIをデプロイしないので、一部環境変数値は空です。