### PR TITLE
upgrade actions/setup-node to v1.4.4

### DIFF
--- a/.github/workflows/publish-draft.yml
+++ b/.github/workflows/publish-draft.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: actions/setup-node@v1.4.2
+      - uses: actions/setup-node@v1.4.4
         with:
           node-version: 12.x
       - uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: actions/setup-node@v1.4.2
+      - uses: actions/setup-node@v1.4.4
         with:
           node-version: 12.x
       - uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
actions/setup-node@v1.4.2で使用している`add-path`というコマンドが11/16で使えなくなりました。

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/