### PR TITLE
プロジェクトとアカウントの確認画面でEnterキーを有効化

### DIFF
--- a/src/.vuepress/components/FormParts/AccountBasicAuth.vue
+++ b/src/.vuepress/components/FormParts/AccountBasicAuth.vue
@@ -67,7 +67,7 @@ export default {
       return this.action + "中です";
     },
     isValid(){
-      return !!this.projectId && !!this.accountId;
+      return (this.projectId !== "") && (this.accountId !== "");
     }
   },
   methods: {

--- a/src/.vuepress/components/FormParts/ProjectBasicAuth.vue
+++ b/src/.vuepress/components/FormParts/ProjectBasicAuth.vue
@@ -52,7 +52,7 @@ export default {
       return this.action + "中です";
     },
     isValid(){
-      return !!this.projectId;
+      return this.projectId !== "";
     }
   },
   methods: {


### PR DESCRIPTION
Enterキーで「確認する」と同じ処理をするようにしました。
プロジェクトとアカウントの組み合わせ確認の画面は、
とりあえずアカウントのほうのみ効くようにしています。

ブラウザによって動きが若干異なり、ChromeとFireFoxで正常に動かすには、
ブラウザのデフォルトのフォーム送信動作を抑止した上で、
keypressかkeydownを使う必要がありました。（keyupはIMEの確定時に反応してしまう）

fix #27 