### PR TITLE
表示項目名の統一

### DIFF
--- a/src/.vuepress/components/FormParts/ProjectInfo.vue
+++ b/src/.vuepress/components/FormParts/ProjectInfo.vue
@@ -71,7 +71,7 @@
           <members :readOnly="!isEditableAttr('Members')" :id="id"/>
         </div>
       </el-form-item>
-      <el-form-item label="所有アカウント" v-show="isExist">
+      <el-form-item label="所有クラウド環境" v-show="isExist">
         <div class="form-item" v-for="account in accountIds">
           <el-button type="text" @click="onClickAccountLink(account)" v-if="isReadOnly">{{account}}</el-button>
           <span v-else>{{account}}</span>

--- a/src/.vuepress/components/FormParts/TicketList.vue
+++ b/src/.vuepress/components/FormParts/TicketList.vue
@@ -10,8 +10,8 @@
       <el-table-column sortable prop="TicketId" label="作業ID"></el-table-column>
       <el-table-column sortable prop="TicketEmail" label="連絡先Eメールアドレス"></el-table-column>
       <el-table-column sortable prop="Type" label="作業種別" :formatter="typeFormatter"></el-table-column>
-      <el-table-column sortable prop="Status" label="作業状況" :formatter="statusFormatter"></el-table-column>
-      <el-table-column sortable prop="CreatedAt" label="作業依頼日" :formatter="epochFormatter" width="160"></el-table-column>
+      <el-table-column sortable prop="Status" label="ステータス" :formatter="statusFormatter"></el-table-column>
+      <el-table-column sortable prop="CreatedAt" label="登録日" :formatter="epochFormatter" width="160"></el-table-column>
       <el-table-column sortable prop="UpdatedAt" label="最終更新日" :formatter="epochFormatter" width="160"></el-table-column>
       <el-table-column width="80">
         <template v-slot="scope">


### PR DESCRIPTION
管理者コンソール側対応の際に教えていただいた3か所を修正しました。他も見てみましたが大丈夫そうでした。

ただ、やはり定例でも出ましたが「プロジェクトの管理者」と「プロジェクト責任者（役割）」は混同しやすく、区別できるように見直す必要がありそうです。
クラウド環境の削除時には、
```
クラウド環境の削除について、プロジェクト代表者へ確認します。
```
というメッセージもありました。（これはプロジェクトの代表者Eメールアドレスってことだから良いのかな・・・）