### PR TITLE
作業種別からCloudFrontキーペア作成を削除

### DIFF
--- a/src/.vuepress/mixins/disp.js
+++ b/src/.vuepress/mixins/disp.js
@@ -39,7 +39,7 @@ const DispNameTable = {
     { value: "GUEST"          , label: "ゲスト" }
   ],
   TicketType: [
-    { value: "REQ_CF_KEYPAIR"          , label: "CloudFrontキーペアの作成" }, 
+//  { value: "REQ_CF_KEYPAIR"          , label: "CloudFrontキーペアの作成" },
     { value: "REQ_AUDIT_LOG"           , label: "監査ログの確認" }, 
     { value: "REQ_SUPPORT_PLAN_CHANGE" , label: "サポートプランの変更" }, 
     { value: "REQ_OTHER"               , label: "その他の作業" }


### PR DESCRIPTION
CloudFrontのキーペア作成にrootユーザー権限が不要になったので、作業種別から選択できないようにしました。

確認してないのですが、おそらく既存のチケットは「不明」扱いになるかと思います。