### PR TITLE
FireFoxのダウンロード拡張子問題対応

### DIFF
--- a/src/.vuepress/components/FormParts/AccountInfo.vue
+++ b/src/.vuepress/components/FormParts/AccountInfo.vue
@@ -449,7 +449,8 @@ export default {
         const blob = await api.download(url, (progress) => {
           updateDownloadStatus("ダウンロードしています...", progress);
         });
-        FileSaver(blob, filename);
+        // [#53] force erase blob type for FireFox
+        FileSaver(blob.slice(0, blob.size, ""), filename);
         updateDownloadStatus("ダウンロードが完了しました。", 100);
       } catch(e) {
         console.error(e);

--- a/src/.vuepress/components/FormParts/ProjectInfo.vue
+++ b/src/.vuepress/components/FormParts/ProjectInfo.vue
@@ -342,7 +342,8 @@ export default {
         const blob = await api.download(url, (progress) => {
           updateDownloadStatus("ダウンロードしています...", progress);
         });
-        FileSaver(blob, filename);
+        // [#53] force erase blob type for FireFox
+        FileSaver(blob.slice(0, blob.size, ""), filename);
         updateDownloadStatus("ダウンロードが完了しました。", 100);
       } catch(e) {
         console.error(e);


### PR DESCRIPTION
Blobのtypeは通常の方法でセットできないため、sliceを使っています。

参考：
https://stackoverflow.com/questions/18998543/set-content-type-on-blob/50875615