### PR TITLE
ファイルの複数選択対応

### DIFF
--- a/src/.vuepress/components/FormParts/AccountInfo.vue
+++ b/src/.vuepress/components/FormParts/AccountInfo.vue
@@ -416,12 +416,12 @@ export default {
         this.operationDate = null;
       }
     },
-    beforeAddFile(filename) {
+    beforeAddFile(filename, uploadList) {
       if(this.files.some(f => f === filename)) {
         this.fileError = "同名のファイルは上書きされます。";
         return true;  // allow
       }
-      if([...new Set(this.files.concat(this.uploadList.map(f => f.name)))].length >= 3){
+      if([...new Set(this.files.concat(uploadList.map(f => f.name)))].length >= 3){
         this.fileError = "申請できるファイルは合計3つまでです。";
         return false;
       }

--- a/src/.vuepress/components/FormParts/ProjectInfo.vue
+++ b/src/.vuepress/components/FormParts/ProjectInfo.vue
@@ -309,12 +309,12 @@ export default {
         });
       });
     },
-    beforeAddFile(filename) {
+    beforeAddFile(filename, uploadList) {
       if(this.files.some(f => f === filename)) {
         this.fileError = "同名のファイルは上書きされます。";
         return true;  // allow
       }
-      if([...new Set(this.files.concat(this.uploadList.map(f => f.name)))].length >= 3){
+      if([...new Set(this.files.concat(uploadList.map(f => f.name)))].length >= 3){
         this.fileError = "申請できるファイルは合計3つまでです。";
         return false;
       }


### PR DESCRIPTION
元は親コンポーネントとv-modelで連携して、ファイルを1つ1つ処理していく想定だったのですが、複数選択された場合には、el-uploadのchangeコールバックが連続発行されるため、親コンポーネントとの連携完了前に次のコールバックが来て不都合がありました。親コンポーネントとダイレクトに連携せず、いったん自身のコンポーネント変数(this.fileList)にバッファすることで1つずつ処理できるように修正しました。イマイチですが。