### PR TITLE
チケット詳細のレイアウト修正

### DIFF
--- a/src/.vuepress/components/FormParts/TicketContent/TicketContentAuditLog.vue
+++ b/src/.vuepress/components/FormParts/TicketContent/TicketContentAuditLog.vue
@@ -5,17 +5,17 @@
       inline-message
       status-icon
       label-width="25%"
-      :label-position="!readOnly?'top':'left'"
+      :label-position="isCreate ?'top':'left'"
       :model="contentModel"
       :rules="rules"
-      :hide-required-asterisk="readOnly"
+      :hide-required-asterisk="isReadOnly"
     >
       <el-form-item label="対象サービス" prop="Service">
         <div class="form-item">
           <el-select
             class="form-item-vshort"
             v-model="service" 
-            v-if="!readOnly"
+            v-if="!isReadOnly"
             placeholder="確認したいサービスを選択してください"
           >
             <el-option
@@ -32,7 +32,7 @@
       </el-form-item>
       <el-form-item label="確認期間" prop="StartDate">
         <div class="form-item">
-          <div id="EditableAuditDate" v-if="!readOnly">
+          <div id="EditableAuditDate" v-if="!isReadOnly">
             <el-date-picker
               v-model="date"
               type="datetimerange"
@@ -52,7 +52,7 @@
         <div class="form-item">
           <el-input
             v-model="note"
-            v-if="!readOnly"
+            v-if="!isReadOnly"
             type="textarea"
             :rows="2"
             placeholder="連絡事項がある場合は、こちらにご記入ください">
@@ -72,9 +72,9 @@ export default {
   name : "TicketContentAuditLog",
   mixins: [Util, Disp],
   props: {
-    readOnly: {
-      type: Boolean,
-      default: false
+    operation: {
+      type: String,
+      default: ""
     },
     id: {
       type: String,
@@ -126,9 +126,9 @@ export default {
     //Store processing
     service: {
       get(){
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           return this.content.Service;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           return this.$store.state.t.updateParams.Content.Service;
         }else{
           return this.$store.state.t.createParams.Content[this.type].Service;
@@ -139,10 +139,10 @@ export default {
     date: {
       get(){
         let start, end;
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           start = this.content.StartDate;
           end = this.content.EndDate;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           start = this.$store.state.t.updateParams.Content.StartDate;
           end = this.$store.state.t.updateParams.Content.EndDate;
         }else{
@@ -158,9 +158,9 @@ export default {
     },
     note: {
       get(){
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           return this.content.Note;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           return this.$store.state.t.updateParams.Content.Note;
         }else{
           return this.$store.state.t.createParams.Content[this.type].Note;
@@ -175,7 +175,7 @@ export default {
       return new Promise((resolve, reject) => {
         // el-form validator
         this.$refs["form"].validate((valid, detail) => {
-          if(this.readOnly){
+          if(this.isReadOnly){
             resolve([]);
           }else{
             resolve(Object.keys(detail).map(d => detail[d][0].message));

--- a/src/.vuepress/components/FormParts/TicketContent/TicketContentPlanChange.vue
+++ b/src/.vuepress/components/FormParts/TicketContent/TicketContentPlanChange.vue
@@ -5,17 +5,17 @@
       inline-message
       status-icon
       label-width="25%"
-      :label-position="!readOnly?'top':'left'"
+      :label-position="isCreate ? 'top':'left'"
       :model="contentModel"
       :rules="rules"
-      :hide-required-asterisk="readOnly"
+      :hide-required-asterisk="isReadOnly"
     >
       <el-form-item label="サポートプラン" prop="ExpectedPlan">
         <div class="form-item">
           <el-select
             class="form-item-vshort"
             v-model="plan" 
-            v-if="!this.readOnly"
+            v-if="!isReadOnly"
             placeholder="変更先のプランを選択してください"
           >
             <el-option
@@ -34,7 +34,7 @@
         <div class="form-item">
           <el-input
             v-model="note"
-            v-if="!this.readOnly"
+            v-if="!isReadOnly"
             type="textarea"
             :rows="2"
             placeholder="連絡事項がある場合は、こちらにご記入ください">
@@ -53,9 +53,9 @@ export default {
   name : "TicketContentPlanChange",
   mixins: [Disp],
   props: {
-    readOnly: {
-      type: Boolean,
-      default: false
+    operation: {
+      type: String,
+      default: ""
     },
     id: {
       type: String,
@@ -94,9 +94,9 @@ export default {
     //Store processing
     plan: {
       get(){
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           return this.content.ExpectedPlan;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           return this.$store.state.t.updateParams.Content.ExpectedPlan;
         }else{
           return this.$store.state.t.createParams.Content[this.type].ExpectedPlan 
@@ -106,9 +106,9 @@ export default {
     },
     note: {
       get(){
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           return this.content.Note;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           return this.$store.state.t.updateParams.Content.Note;
         }else{
           return this.$store.state.t.createParams.Content[this.type].Note 
@@ -123,7 +123,7 @@ export default {
       return new Promise((resolve, reject) => {
         // el-form validator
         this.$refs["form"].validate((valid, detail) => {
-          if(this.readOnly){
+          if(this.isReadOnly){
             resolve([]);
           }else{
             resolve(Object.keys(detail).map(d => detail[d][0].message));

--- a/src/.vuepress/components/FormParts/TicketContent/TicketContentSimple.vue
+++ b/src/.vuepress/components/FormParts/TicketContent/TicketContentSimple.vue
@@ -1,27 +1,35 @@
 <template>
   <div id="TicketContentSimple">
-    <el-form-item label="備考">
-      <div class="form-item">
-        <el-input
-          v-model="note"
-          v-if="!this.readOnly"
-          type="textarea"
-          :rows="2"
-          placeholder="連絡事項がある場合は、こちらにご記入ください">
-        </el-input>
-        <span v-else>{{note}}</span>
-      </div>
-    </el-form-item>
+    <el-form
+      label-width="25%"
+      :label-position="isCreate ? 'top':'left'"
+    >
+      <el-form-item label="備考">
+        <div class="form-item">
+          <el-input
+            v-model="note"
+            v-if="!isReadOnly"
+            type="textarea"
+            :rows="2"
+            placeholder="連絡事項がある場合は、こちらにご記入ください">
+          </el-input>
+          <span v-else>{{note}}</span>
+        </div>
+      </el-form-item>
+    </el-form>
   </div>
 </template>
 
 <script>
+import Disp from "../../../mixins/disp";
+
 export default {
   name : "TicketContentSimple",
+  mixins: [Disp],
   props: {
-    readOnly: {
-      type: Boolean,
-      default: false
+    operation: {
+      type: String,
+      default: ""
     },
     id: {
       type: String,
@@ -44,9 +52,9 @@ export default {
     //Store processing
     note: {
       get(){
-        if(this.hasId && this.readOnly){
+        if(this.hasId && this.isReadOnly){
           return this.content.Note;
-        }else if(this.hasId && !this.readOnly){
+        }else if(this.hasId && !this.isReadOnly){
           return this.$store.state.t.updateParams.Content.Note;
         }else{
           return this.$store.state.t.createParams.Content[this.type].Note 

--- a/src/.vuepress/components/FormParts/TicketInfo.vue
+++ b/src/.vuepress/components/FormParts/TicketInfo.vue
@@ -57,10 +57,10 @@
         </div>
       </el-form-item>
       <div id="TicketContent">
-        <simple v-if="isShowContent('REQ_CF_KEYPAIR')" type="REQ_CF_KEYPAIR" :readOnly="isReadOnly" :id="id"/>
-        <simple v-if="isShowContent('REQ_OTHER')" type="REQ_OTHER" :readOnly="isReadOnly" :id="id"/>
-        <audit ref="content" v-if="isShowContent('REQ_AUDIT_LOG')" :readOnly="isReadOnly" :id="id"/>
-        <plan ref="content" v-if="isShowContent('REQ_SUPPORT_PLAN_CHANGE')" :readOnly="isReadOnly" :id="id"/>
+        <simple v-if="isShowContent('REQ_CF_KEYPAIR')" type="REQ_CF_KEYPAIR" :operation="operation" :id="id"/>
+        <simple v-if="isShowContent('REQ_OTHER')" type="REQ_OTHER" :operation="operation" :id="id"/>
+        <audit ref="content" v-if="isShowContent('REQ_AUDIT_LOG')" :operation="operation" :id="id"/>
+        <plan ref="content" v-if="isShowContent('REQ_SUPPORT_PLAN_CHANGE')" :operation="operation" :id="id"/>
       </div>
       <el-form-item label="登録日" v-if="isReadOnly">
         <span class="form-item">{{epochSecToJST(createdAt)}}</span>


### PR DESCRIPTION
今までの`readOnly`による2値判断が難しいため、
`operation`を伝搬させて、他コンポーネントと同様に対応しています。