### PR TITLE
監査ログが依頼できない問題の修正

### DIFF
--- a/src/.vuepress/components/FormParts/TicketContent/TicketContentAuditLog.vue
+++ b/src/.vuepress/components/FormParts/TicketContent/TicketContentAuditLog.vue
@@ -149,9 +149,10 @@ export default {
               const end = new Date(this.date[1]);
               if(start.getTime() === end.getTime()){
                 callback("確認期間の開始時刻と終了時刻が同じです。");
-              }
-              if(start < end.setDate(end.getDate() - 30)) {
+              }else if(start < end.setDate(end.getDate() - 30)) {
                 callback("一度に依頼できる期間は最大で30日間です。");
+              }else{
+                callback();
               }
             }
           }}


### PR DESCRIPTION
大変申し訳ございません。BigBugでした。
`el-form`のカスタムバリデーション(async-validator)で正常時がノーケアでした。
正常時も空（エラーなし）でコールバックする必要がありました。