### PR TITLE
表示名の不整合を解消

### DIFF
--- a/src/.vuepress/mixins/disp.js
+++ b/src/.vuepress/mixins/disp.js
@@ -11,7 +11,7 @@ const DispNameTable = {
     { value: "PRD", label: "本番" },
     { value: "STG", label: "ステージング" },
     { value: "DEV", label: "開発" },
-    { value: "POC", label: "概念検証" }
+    { value: "POC", label: "概念実証" }
   ],
   AccountStatus: [
     { value: "WAITING_CONFIRM"  , label: "承認待ち" },
@@ -52,7 +52,7 @@ const DispNameTable = {
   ],
   ServiceForAudit: [
     { value: "AWS_CONFIG"     , label: "AWS Config" }, 
-    { value: "AWS_CLOUDTRAIL" , label: "Amazon CloudTrail" }
+    { value: "AWS_CLOUDTRAIL" , label: "AWS CloudTrail" }
   ],
   SupportPlan: [
     { value: "BUSINESS" , label: "ビジネス" },

--- a/src/guide/aws/reference/baseline.md
+++ b/src/guide/aws/reference/baseline.md
@@ -185,7 +185,7 @@ StackSet-AWSControlTowerBP-BASELINE-XXX
 どの程度の料金が掛かるのか、以下に3つのプロジェクトにおける、過去2か月分の請求サンプルを載せますので、参考にしてください。
 
 ::: tip NOTE
-実際には、*AWS Config*、*Amazon CloudTrail*、*Amazon GuardDuty* 以外のサービスもベースラインでは利用していますが、大きく割合を占めるものでは無いため、ここでは割愛します。
+実際には、*AWS Config*、*AWS CloudTrail*、*Amazon GuardDuty* 以外のサービスもベースラインでは利用していますが、大きく割合を占めるものでは無いため、ここでは割愛します。
 :::
 
 - サンプル１


### PR DESCRIPTION
少々面倒なので、Issue化せずにやってしまいます。
以下の対応を実施。


- [要望]アカウント登録の利用目的は、ヒント先のユーザガイドは概念実証、ポータル選択肢は概念検証で異なっているので合わせるといいと思う。

- [要望]管理者作業の監査ログの確認の対象サービスは、ヒント先ではどちらもAWS ～となっているが、依頼時の選択肢では、Amazon CloudTrailとAWS Config になっている。あえてそうしている？