### PR TITLE
マネージドコスト配分タグのお知らせ追加

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -43,6 +43,7 @@ module.exports = {
               { text: "AWSの利用を開始する", link: "/guide/aws/startup" },
               { text: "基本的な使い方", link: "/guide/aws/usecase" },
               { text: "提供サービス", link: "/guide/aws/service" },
+              { text: "よくある質問", link: "/guide/aws/faq" },
               { text: "リファレンス", link: "/guide/aws/reference" }
             ]
           }

--- a/src/guide/aws/faq.md
+++ b/src/guide/aws/faq.md
@@ -36,3 +36,23 @@ OrBITではセキュリティポリシーに準拠するため、*AWS Config*の
 - 記録対象のリソースを制限します。詳細は下記を参照してください。
     -  [「AWS Config でサポートされている AWS リソースタイプとリソース関係」](https://docs.aws.amazon.com/ja_jp/config/latest/developerguide/resource-config-reference.html)
     - [「AWS Config で記録するリソースの選択」](https://docs.aws.amazon.com/ja_jp/config/latest/developerguide/select-resources.html)
+
+### Q. EC2インスタンスなどリソース毎に料金を確認する方法はありませんか？
+OrBITでは以下のコスト配分タグを有効にしており、コスト把握に利用することができます。
+
+| タグ名 | 想定用途 | 例 |
+| :-- | :-- | :-- |
+| `orbit:cost:Project` | プロジェクト単位での確認 | `orbit:cost:Project` = orbit |
+| `orbit:cost:Group` | グループ単位での確認 | `orbit:cost:Group` = ServerGroup |
+| `orbit:cost:Name` | リソース毎の確認 | `orbit:cost:Name` = Server1 |
+| `orbit:cost:Env` | 環境毎の確認 | `orbit:cost:Env` = dev |
+
+EC2などのタグを付与できるサービスにて、上記タグを付与することでタグ毎に使用しているコストを把握できるようになります。
+
+コストの把握には ***AWS Cost Explorer*** を使用すると便利です。
+使い方については[「こちら」](https://aws.amazon.com/jp/blogs/news/cost-allocation-tag/)を参考にしてください。
+
+::: tip
+OrBITの仕組み上、プロジェクトで利用しているAWSアカウント上ではコスト配分タグを有効にすることはできません。
+上記以外のタグを希望する際は、[「こちら」](/support/contact.html)よりお問い合わせください。
+:::

--- a/src/information/summary.md
+++ b/src/information/summary.md
@@ -7,23 +7,25 @@ OrBITのリリース情報やメンテナンス情報を掲載しています。
 
 ---
 
-## AWS利用時におけるセッション有効時間を変更しました
+## コスト配分タグの提供を開始しました
 <Badge text="リリース情報" type="tip" vertical="bottom"/>
 <Badge text="AWS" type="note" vertical="bottom"/>
 
-**投稿日 : 2021/9/2(木)**
+**投稿日 : 2021/11/1(月)**
 
-本日、以下のアクセス権限についてセッション有効時間を変更しました。
+本日、以下のコスト配分タグを有効にしました。
 
-| アクセス権限名称 | 変更前 | 変更後 |
-| :--: | :--: | :--: |
-| AWSAdministratorAccess | 1時間 | 12時間 |
-| AWSPowerUserAccess | 8時間 | 12時間 |
+| タグ名 | 想定用途 | 例 |
+| :-- | :-- | :-- |
+| `orbit:cost:Project` | プロジェクト単位での確認 | `orbit:cost:Project` = orbit |
+| `orbit:cost:Group` | グループ単位での確認 | `orbit:cost:Group` = ServerGroup |
+| `orbit:cost:Name` | リソース毎の確認 | `orbit:cost:Name` = Server1 |
+| `orbit:cost:Env` | 環境毎の確認 | `orbit:cost:Env` = dev |
 
-アクセス権限の詳細については、[こちら](/guide/aws/service/id-management.html#アクセス権限の一覧)をご覧下さい。
+EC2などのタグを付与できるサービスにて、上記タグを付与することでタグ毎に使用しているコストを把握できるようになります。
 
-この変更でより効率的に開発を進めることができるようになります。
-引き続き、OrBITをご利用ください。
+コストの把握には ***AWS Cost Explorer*** を使用すると便利です。
+使い方については[「こちら」](https://aws.amazon.com/jp/blogs/news/cost-allocation-tag/)を参考にしてください。
 
 ## ユーザーガイドの更新やナレッジの追加を行いました
 <Badge text="リリース情報" type="tip" vertical="bottom"/>


### PR DESCRIPTION
メンバーアカウント上だとコスト配分タグを有効にできないということが分かり
必要最低限のコスト配分タグを追加、アクティブにしました。

その内容を「おしらせ」と「よくある質問」に追加したので確認をお願いします。
※ついでにナビバーにも「よくある質問」を追加

尚、ドキュメントの更新については`hotfix`扱いとし、`master`ブランチにマージした後に`dev`にも適用します。

dev環境にはデプロイ済みですので確認してみてください。